### PR TITLE
Add store pages reference to root sitemap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add individual store pages list reference to root sitemap
+
 ## [0.0.4] - 2020-11-17
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,7 @@
     "vtex.rich-text": "0.x",
     "vtex.store-graphql": "2.x",
     "vtex.store-components": "3.x",
+    "vtex.store-sitemap": "2.x",
     "vtex.styleguide": "9.x",
     "vtex.render-runtime": "8.x",
     "vtex.css-handles": "0.x"
@@ -47,23 +48,12 @@
     {
       "name": "outbound-access",
       "attrs": {
-        "host": "{{account}}.vtexcommercestable.com.br",
-        "path": "/api/checkout/pub/pickup-points/*"
-      }
-    },
-    {
-      "name": "outbound-access",
-      "attrs": {
-        "host": "portal.vtexcommercestable.com.br",
-        "path": "/api/segments/*"
-      }
-    },
-    {
-      "name": "outbound-access",
-      "attrs": {
         "host": "liveapi.yext.com",
         "path": "/*"
       }
+    },
+    {
+      "name": "vtex.store-sitemap:resolve-graphql"
     },
     {
       "name": "LogisticsViewer"

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -1,10 +1,15 @@
 import { IOClients } from '@vtex/api'
 
 import Yext from './yext'
+import Sitemap from './sitemap'
 
 // Extend the default IOClients implementation with our own custom clients.
 export class Clients extends IOClients {
   public get yext() {
     return this.getOrSet('yext', Yext)
+  }
+
+  public get sitemap() {
+    return this.getOrSet('sitemap', Sitemap)
   }
 }

--- a/node/clients/sitemap.ts
+++ b/node/clients/sitemap.ts
@@ -1,0 +1,39 @@
+import { AppGraphQLClient, InstanceOptions, IOContext } from '@vtex/api'
+
+const saveIndexMutation = `mutation SaveIndex($index: String!) {
+    saveIndex(index: $index)
+}`
+
+export default class Sitemap extends AppGraphQLClient {
+  constructor(ctx: IOContext, opts?: InstanceOptions) {
+    super('vtex.store-sitemap@2.x', ctx, opts)
+  }
+
+  public hasSitemap() {
+    return this.http
+      .get(
+        `http://${this.context.workspace}--${this.context.account}.myvtex.com/sitemap.xml`
+      )
+      .then((ret: string) => ret.indexOf('store-locator') !== -1)
+  }
+
+  public async saveIndex() {
+    const { tenant } = this.context
+
+    this.graphql.mutate(
+      {
+        mutate: saveIndexMutation,
+        variables: { index: 'store-locator' },
+      },
+      {
+        headers: {
+          ...(this.options && this.options.headers),
+          'Proxy-Authorization': this.context.authToken,
+          VtexIdclientAutCookie: this.context.authToken,
+          'x-vtex-tenant': tenant,
+        },
+        metric: 'storelocator-save-root-index',
+      }
+    )
+  }
+}

--- a/node/graphql/index.ts
+++ b/node/graphql/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { method } from '@vtex/api'
+import { LogLevel, method } from '@vtex/api'
 import slugify from 'slugify'
 
 import { Entity, EntityCustomFields } from '../typings/yextLocations'
@@ -253,12 +253,23 @@ export const resolvers = {
     getStores: async (_: any, param: any, ctx: Context) => {
       const { location, limit, filter } = param
       const {
-        clients: { apps, yext },
+        clients: { apps, yext, sitemap },
+        vtex: { logger },
       } = ctx
 
       const appId = process.env.VTEX_APP_ID as string
       const settings = await apps.getAppSettings(appId)
       const { apiKey, use24Hour, defaultLocation } = settings
+
+      try {
+        sitemap.hasSitemap().then((has: any) => {
+          if (has === false) {
+            sitemap.saveIndex()
+          }
+        })
+      } catch (err) {
+        logger.log(err, LogLevel.Error)
+      }
 
       const { response } = await yext.getLocationsByAddress({
         apiKey,

--- a/node/package.json
+++ b/node/package.json
@@ -13,7 +13,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.37.0",
+    "@vtex/api": "6.37.1",
     "@vtex/prettier-config": "^0.3.1",
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.18.0",
@@ -25,7 +25,8 @@
     "vtex.rich-text": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rich-text@0.11.1/public/@types/vtex.rich-text",
     "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.105.0/public/@types/vtex.store",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.134.0/public/@types/vtex.store-graphql",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.130.1/public/@types/vtex.styleguide"
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.130.1/public/@types/vtex.styleguide",
+    "vtex.store-sitemap": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.4/public/@types/vtex.store-sitemap"
   },
   "scripts": {
     "lint": "tsc --noEmit && tslint -c tslint.json './**/*.ts'"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -165,10 +165,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@6.37.0":
-  version "6.37.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.37.0.tgz#a07e6adbfc02866f901cf0cfff2155f2c279adc5"
-  integrity sha512-Vy970ZfgOttrxeiJW2oM8rQ0E8t/HE5cQhbGIawfJsu35HEWA9NnWRSR3bdLMczT9oYIY9QwE8IfdU4b44dhKw==
+"@vtex/api@6.37.1":
+  version "6.37.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.37.1.tgz#d6ded4f4a98e10596729af7097cff18be43a0e54"
+  integrity sha512-24BaVHCIbkC84UWAlGPuTnUYIFngOpeRa4u/6KCJDnir5GXjoCWAkj4E7OoQ2uvBy/uvs9X2+DIkqtiz1x5bvw==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1623,6 +1623,10 @@ vary@^1.1.2:
 "vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.134.0/public/@types/vtex.store-graphql":
   version "2.134.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.134.0/public/@types/vtex.store-graphql#b063516516353a5c7476699d1399c4582a4427b7"
+
+"vtex.store-sitemap@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.4/public/@types/vtex.store-sitemap":
+  version "2.13.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.4/public/@types/vtex.store-sitemap#1b54dd14634c27621186d86aaefbe9fde9e29d1c"
 
 "vtex.store@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.105.0/public/@types/vtex.store":
   version "2.105.0"


### PR DESCRIPTION
#### What problem is this solving?

Individual store pages are not added to the root sitemap.

#### How to test it?

https://sdb--worldwidegolf.myvtex.com/sitemap.xml
https://sdb--worldwidegolf.myvtex.com/sitemap/store-locator.xml

#### Screenshots or example usage:

![Screenshot from 2021-01-04 13-48-45](https://user-images.githubusercontent.com/22715037/103568493-9f9da580-4e93-11eb-920b-e44623945c67.png)

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
