### PR TITLE
Add default api request headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add default headers to Yext api request
+
 ## [0.0.5] - 2021-01-04
 
 ### Added

--- a/node/clients/yext.ts
+++ b/node/clients/yext.ts
@@ -30,7 +30,13 @@ const CLOSED_STORES_FILTER = '%7B%22closed%22%3A%7B%22%24eq%22%3Afalse%7D%7D'
 
 export default class Yext extends ExternalClient {
   constructor(context: IOContext, options?: InstanceOptions) {
-    super('https://liveapi.yext.com', context, options)
+    super('http://liveapi.yext.com', context, {
+      ...options,
+      headers: {
+        'X-Vtex-Use-Https': 'true',
+        'Proxy-Authorization': context.authToken,
+      },
+    })
   }
 
   public async getLocationsByAddress({


### PR DESCRIPTION
#### What problem is this solving?

Adding default request headers to handle `https` requests.

#### How to test it?

https://sdb--worldwidegolf.myvtex.com/storelocator

