### PR TITLE
Check for storeId before query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent store query without store ID
+
 ## [0.0.6] - 2021-01-05
 
 ### Added

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1402,7 +1402,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/StoreGroup.tsx
+++ b/react/StoreGroup.tsx
@@ -17,9 +17,9 @@ const StoreGroup: StorefrontFunctionComponent<StoreGroupProps> = ({
   const { history } = useRuntime()
   const [getStore, { data, called }] = useLazyQuery<StoreResult>(GET_STORE)
 
-  if (history && !called) {
-    const locationId = history.location.state.navigationRoute.params.store_id
+  const locationId = history?.location.state.navigationRoute.params.store_id
 
+  if (locationId && !called) {
     getStore({
       variables: {
         locationId,


### PR DESCRIPTION
#### What problem is this solving?

Many errors being reported in Splunk around the getStore query. 

```
     message: Variable "$locationId" of required type "String!" was not provided.
     name: GraphQLError
     operationId: f055ef30-9635-4873-a045-da70c5140512
     query: { [-]
       operationName: getStore
       query: query getStore($locationId: String!) {
```

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

https://sdb--worldwidegolf.myvtex.com/store/golfers-warehouse-ct-06114/HFD

