### PR TITLE
Fix messages key order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Map pin info not being displayed due to `intl` error
+
 ## [0.0.7] - 2021-01-18
 
 ### Fixed

--- a/messages/context.json
+++ b/messages/context.json
@@ -19,7 +19,6 @@
   "store/yext-store-locator.short-day-thursday": "store/yext-store-locator.short-day-thursday",
   "store/yext-store-locator.short-day-friday": "store/yext-store-locator.short-day-friday",
   "store/yext-store-locator.short-day-saturday": "store/yext-store-locator.short-day-saturday",
-  "store/yext-store-locator.hours-label": "store/yext-store-locator.hours-label",
   "admin/editor.storeAddress.title": "admin/editor.storeAddress.title",
   "admin/editor.storeAddress.description": "admin/editor.storeAddress.description",
   "admin/editor.storeAddressLabel.title": "admin/editor.storeAddressLabel.title",
@@ -106,6 +105,7 @@
   "admin/editor.StoreSocialLinksYouTubeHandle.description": "admin/editor.StoreSocialLinksYouTubeHandle.description",
   "admin/editor.StoreTitle.title": "admin/editor.StoreTitle.title",
   "admin/editor.StoreTitle.description": "admin/editor.StoreTitle.description",
+  "store/yext-store-locator.hours-label": "store/yext-store-locator.hours-label",
   "admin/editor.storeUberLink.title": "admin/editor.storeUberLink.title",
   "admin/editor.storeUberLink.description": "admin/editor.storeUberLink.description"
 }

--- a/node/package.json
+++ b/node/package.json
@@ -13,7 +13,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.37.1",
+    "@vtex/api": "6.41.0",
     "@vtex/prettier-config": "^0.3.1",
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.18.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -165,10 +165,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@6.37.1":
-  version "6.37.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.37.1.tgz#d6ded4f4a98e10596729af7097cff18be43a0e54"
-  integrity sha512-24BaVHCIbkC84UWAlGPuTnUYIFngOpeRa4u/6KCJDnir5GXjoCWAkj4E7OoQ2uvBy/uvs9X2+DIkqtiz1x5bvw==
+"@vtex/api@6.41.0":
+  version "6.41.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.41.0.tgz#cee074ff49de8a5de92f3d353a4689275cb92f7b"
+  integrity sha512-RvfdpczsxCFacZkDSl2v2NmfD/bHFxHHn2xQsEwSQ+40snGxfOz56TlCbPbgMEtkC8Bf+1GGUkCIChRE6xnlLg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1402,7 +1402,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/components/Pinpoints.tsx
+++ b/react/components/Pinpoints.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 import React, { useState } from 'react'
-import { defineMessages, FormattedMessage, injectIntl } from 'react-intl'
+import { useIntl, defineMessages } from 'react-intl'
 import {
   GoogleMap,
   Marker,
@@ -32,6 +32,41 @@ const CSS_HANDLES = [
   'markerInfoAddress',
 ] as const
 
+const messages = defineMessages({
+  hoursLabel: {
+    defaultMessage: '',
+    id: 'store/yext-store-locator.hours-label',
+  },
+  '0': {
+    defaultMessage: '',
+    id: 'store/yext-store-locator.short-day-sunday',
+  },
+  '1': {
+    defaultMessage: '',
+    id: 'store/yext-store-locator.short-day-monday',
+  },
+  '2': {
+    defaultMessage: '',
+    id: 'store/yext-store-locator.short-day-tuesday',
+  },
+  '3': {
+    defaultMessage: '',
+    id: 'store/yext-store-locator.short-day-wednesday',
+  },
+  '4': {
+    defaultMessage: '',
+    id: 'store/yext-store-locator.short-day-thursday',
+  },
+  '5': {
+    defaultMessage: '',
+    id: 'store/yext-store-locator.short-day-friday',
+  },
+  '6': {
+    defaultMessage: '',
+    id: 'store/yext-store-locator.short-day-saturday',
+  },
+})
+
 interface PinpointProps {
   items: SpecificationGroup[]
   onChangeCenter: (lon: number, lat: number, zoomSize: number) => void
@@ -40,7 +75,6 @@ interface PinpointProps {
   icon: string
   iconWidth: string
   iconHeight: string
-  intl: any
 }
 
 const Pinpoints = withScriptjs(
@@ -50,43 +84,10 @@ const Pinpoints = withScriptjs(
     })
 
     const handles = useCssHandles(CSS_HANDLES)
-
-    const messages = defineMessages({
-      hoursLabel: {
-        defaultMessage: '',
-        id: 'store/yext-store-locator.hours-label',
-      },
-      '0': {
-        defaultMessage: '',
-        id: 'store/yext-store-locator.short-day-sunday',
-      },
-      '1': {
-        defaultMessage: '',
-        id: 'store/yext-store-locator.short-day-monday',
-      },
-      '2': {
-        defaultMessage: '',
-        id: 'store/yext-store-locator.short-day-tuesday',
-      },
-      '3': {
-        defaultMessage: '',
-        id: 'store/yext-store-locator.short-day-wednesday',
-      },
-      '4': {
-        defaultMessage: '',
-        id: 'store/yext-store-locator.short-day-thursday',
-      },
-      '5': {
-        defaultMessage: '',
-        id: 'store/yext-store-locator.short-day-friday',
-      },
-      '6': {
-        defaultMessage: '',
-        id: 'store/yext-store-locator.short-day-saturday',
-      },
-    })
-
     const { navigate } = useRuntime()
+    const { formatMessage } = useIntl()
+    const [lng, lat] = props.center
+    const { zoom } = props
 
     const handleMarkState = (id: string) => {
       const markerState = !state.markerState[id]
@@ -99,9 +100,6 @@ const Pinpoints = withScriptjs(
         markerState,
       })
     }
-
-    const [lng, lat] = props.center
-    const { intl, zoom } = props
 
     const goTo = (item: any) => {
       const { state: _state, postalCode } = item.address
@@ -186,7 +184,7 @@ const Pinpoints = withScriptjs(
                           className={handles.markerInfoHours}
                         >
                           <span className="">
-                            {intl.formatMessage(messages[hours.dayOfWeek])}
+                            {formatMessage(messages[hours.dayOfWeek])}
                           </span>
                           <br />
                           <span className="">{hours.hoursDisplay}</span>
@@ -198,7 +196,9 @@ const Pinpoints = withScriptjs(
                       className={`${handles.markerInfoDirectionsLink} vtex-link`}
                       href={item.googleMapLink}
                     >
-                      <FormattedMessage id="store/yext-store-locator.pinpoints.directions" />
+                      {formatMessage({
+                        id: 'store/yext-store-locator.pinpoints.directions',
+                      })}
                     </a>
                   </div>
                 </InfoWindow>
@@ -211,4 +211,4 @@ const Pinpoints = withScriptjs(
   })
 )
 
-export default injectIntl(Pinpoints)
+export default Pinpoints


### PR DESCRIPTION
#### What problem is this solving?

Map pin info text is failing to load due to missing `<IntlProvider>`

[See live site](https://www.worldwidegolfshops.com/storelocator)

```
react_devtools_backend.js:2430 Invariant Violation: [React Intl] Could not find required `intl` object. <IntlProvider> needs to exist in the component ancestry.
    at ue (https://worldwidegolf.vtexassets.com/_v/public/assets/v1/npm/react-intl@3.9.1/dist/react-intl.min.js?async=2&workspace=filterimprovements:2:31216)
    at me (https://worldwidegolf.vtexassets.com/_v/public/assets/v1/npm/react-intl@3.9.1/dist/react-intl.min.js?async=2&workspace=filterimprovements:2:31564)
    at https://worldwidegolf.vtexassets.com/_v/public/assets/v1/npm/react-intl@3.9.1/dist/react-intl.min.js?async=2&workspace=filterimprovements:2:49040
    at fk (https://worldwidegolf.vtexassets.com/_v/public/assets/v1/npm/react-dom@0.0.0-experimental-94c0244ba/umd/react-dom.production.min.js?async=2&workspace=filterimprovements:249:96)
    at li (https://worldwidegolf.vtexassets.com/_v/public/assets/v1/npm/react-dom@0.0.0-experimental-94c0244ba/umd/react-dom.production.min.js?async=2&workspace=filterimprovements:177:477)
    at dk (https://worldwidegolf.vtexassets.com/_v/public/assets/v1/npm/react-dom@0.0.0-experimental-94c0244ba/umd/react-dom.production.min.js?async=2&workspace=filterimprovements:177:408)
    at Bc (https://worldwidegolf.vtexassets.com/_v/public/assets/v1/npm/react-dom@0.0.0-experimental-94c0244ba/umd/react-dom.production.min.js?async=2&workspace=filterimprovements:177:268)
    at sf (https://worldwidegolf.vtexassets.com/_v/public/assets/v1/npm/react-dom@0.0.0-experimental-94c0244ba/umd/react-dom.production.min.js?async=2&workspace=filterimprovements:170:444)
    at https://worldwidegolf.vtexassets.com/_v/public/assets/v1/npm/react-dom@0.0.0-experimental-94c0244ba/umd/react-dom.production.min.js?async=2&workspace=filterimprovements:75:176
    at unstable_runWithPriority (https://worldwidegolf.vtexassets.com/_v/public/assets/v1/npm/react@0.0.0-experimental-94c0244ba/umd/react.production.min.js?async=2&workspace=filterimprovements:25:295)
```
<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://sdb--worldwidegolf.myvtex.com/storelocator)

#### Screenshots or example usage:

![Screenshot from 2021-03-16 13-31-56](https://user-images.githubusercontent.com/22715037/111368903-0ab9e400-865c-11eb-9016-0e40199a1629.png)


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
